### PR TITLE
fix: catppuccin icon size

### DIFF
--- a/json/catppuccin.json
+++ b/json/catppuccin.json
@@ -20,7 +20,7 @@
 			"stackblitz",
 			"vercel"
 		],
-		"height": 24,
+		"height": 16,
 		"category": "Programming",
 		"palette": true
 	},
@@ -1633,5 +1633,7 @@
 		"maven": {
 			"parent": "apache"
 		}
-	}
+	},
+	"width": 16,
+	"height": 16
 }


### PR DESCRIPTION
Hi, I realized the icon size wasn't set at the root and the one specified in info seemed wrong as all icons are 16*16 in the catppuccin icons.

I had issues when trying to use them with https://github.com/yuyinws/vitepress-plugin-group-icon and it uses the size data to recreate the icons so i ended up having viewbox of 0 0 0 0.