### PR TITLE
fix: _dirname assignment for turborepo module compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,9 @@ export type IconifyMetaDataCollection = {
 };
 
 const _dirname =
-  typeof __dirname !== 'undefined'
-    ? __dirname
-    : dirname(fileURLToPath(import.meta.url));
+  typeof import.meta !== "undefined" && import.meta.url
+    ? dirname(fileURLToPath(import.meta.url))
+    : __dirname;
 
 /**
  * Directory of this package


### PR DESCRIPTION
### Fix dirname resolution in ESM/CJS environments (Turborepo compatible)

This change fixes inconsistent `dirname` resolution when the package is executed in different module systems and monorepo environments.

#### Problem

<img width="742" height="517" alt="image" src="https://github.com/user-attachments/assets/a67d1983-d72a-431f-aef2-fe62214de88e" />

When running inside **Turborepo**, some tasks resolve paths under a virtual root (`/ROOT/...`), while others use the real absolute filesystem path.
This caused mismatches such as:

* `prev`: `/ROOT/apps/docs/node_modules/...`
* `current`: `/Users/.../apps/docs/node_modules/...`

The issue was triggered by relying directly on `__dirname` or ad-hoc fallbacks, which behave differently between **ESM**, **CJS**, and Turborepo’s sandboxed execution.

#### Solution

* Uses `import.meta.url` when running in ESM
* Falls back to `__dirname` in CJS
