### PR TITLE
Change Röntgen category from UI to maps

### DIFF
--- a/collections.json
+++ b/collections.json
@@ -1906,7 +1906,7 @@
 			"pyramid"
 		],
 		"height": 16,
-		"category": "UI 16px / 32px",
+		"category": "Flags / Maps",
 		"tags": [
 			"Precise Shapes",
 			"Has Padding"

--- a/json/roentgen.json
+++ b/json/roentgen.json
@@ -21,7 +21,7 @@
 			"pyramid"
 		],
 		"height": 16,
-		"category": "UI 16px / 32px",
+		"category": "Flags / Maps",
 		"tags": [
 			"Precise Shapes",
 			"Has Padding"


### PR DESCRIPTION
Hi, Vjacheslav!

I'm Sergey, the creator of Röntgen icon set. Hope this is the right place to modify configuration files. I tried to change the category of the icon set from "UI" to "Flags / Maps".

If it is OK, I would like also request a change to the icon samples in a following PR.

Thank you for your project!